### PR TITLE
Fix UnauthorizedAccessException on special pointer directories & UpdateUI sometimes being called too early.

### DIFF
--- a/Explode/Form1.Designer.cs
+++ b/Explode/Form1.Designer.cs
@@ -111,6 +111,7 @@ namespace Explode
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "Form1";
             this.Text = "Explode";
+            this.Load += new System.EventHandler(this.Form1_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);

--- a/Explode/Form1.cs
+++ b/Explode/Form1.cs
@@ -28,6 +28,15 @@ namespace Explode
                 // makes sure the new folder actually exists
                 if (Directory.Exists(value))
                 {
+                    //verify the user has sufficient access to the directory
+                    //this will trigger on certain special pointer directories (ie. legacy symlinks like Application Data)
+                    try {
+                        Directory.GetFileSystemEntries(value);
+                    } catch (UnauthorizedAccessException) {
+                        MessageBox.Show("You don't have permission to access this directory.", "Unauthorized Access", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+
                     // if it doesn't end with a /, add one
                     if (value.Replace("\\", "/").EndsWith("/") == false)
                     {

--- a/Explode/Form1.cs
+++ b/Explode/Form1.cs
@@ -12,7 +12,6 @@ namespace Explode
         public Form1()
         {
             InitializeComponent();
-            CurrentDirectory = "C:/Users";
         }
 
         // Creates a new plugin manager system and loads plugins
@@ -117,6 +116,10 @@ namespace Explode
             }
 
             return data;
+        }
+
+        private void Form1_Load(object sender, EventArgs e) {
+            CurrentDirectory = "C:/Users";
         }
     }
 }


### PR DESCRIPTION
Windows has some legacy stuff in place that can cause UnauthorizedAccessException, for example, the 'Application Data' symlink (ish) in user directories.

A more user-friendly application like Windows Explorer would hide these, but since this application is intended for tinkerers, this may be a more fitting solution.

EDIT: Also fixed UpdateUI occasionally being called too early on launch ([this exception](https://paste.ee/p/ByimH)) by putting the initial directory set into a Form1 Load event.